### PR TITLE
Refactor: 레시피 창 텍스트 공백 수정

### DIFF
--- a/lib/src/recipe/view/recipe_view.dart
+++ b/lib/src/recipe/view/recipe_view.dart
@@ -67,13 +67,17 @@ class RecipeView extends StatelessWidget {
           decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(12.0),
               color: Color(0xffF3F3F3)),
-          child: TextField(
-              decoration: InputDecoration(
-            hintText: " 검색어를 입력해 주세요.",
-            hintStyle: Theme.of(context).textTheme.labelMedium,
-            border: InputBorder.none,
-            suffixIcon: Icon(Icons.search, size: 24, color: Color(0xff2A2A2A)),
-          )),
+          child: Padding(
+            padding: const EdgeInsets.only(left: 14),
+            child: TextField(
+                decoration: InputDecoration(
+              hintText: "검색어를 입력해 주세요.",
+              hintStyle: Theme.of(context).textTheme.labelMedium,
+              border: InputBorder.none,
+              suffixIcon:
+                  Icon(Icons.search, size: 24, color: Color(0xff2A2A2A)),
+            )),
+          ),
         );
       });
 

--- a/lib/src/recipe/view/recipe_view.dart
+++ b/lib/src/recipe/view/recipe_view.dart
@@ -67,17 +67,15 @@ class RecipeView extends StatelessWidget {
           decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(12.0),
               color: Color(0xffF3F3F3)),
-          child: Padding(
-            padding: const EdgeInsets.only(left: 14),
-            child: TextField(
-                decoration: InputDecoration(
-              hintText: "검색어를 입력해 주세요.",
-              hintStyle: Theme.of(context).textTheme.labelMedium,
-              border: InputBorder.none,
-              suffixIcon:
-                  Icon(Icons.search, size: 24, color: Color(0xff2A2A2A)),
-            )),
-          ),
+          child: TextField(
+              decoration: InputDecoration(
+            hintText: "검색어를 입력해 주세요.",
+            contentPadding:
+                EdgeInsetsDirectional.symmetric(vertical: 10, horizontal: 10),
+            hintStyle: Theme.of(context).textTheme.labelMedium,
+            border: InputBorder.none,
+            suffixIcon: Icon(Icons.search, size: 24, color: Color(0xff2A2A2A)),
+          )),
         );
       });
 


### PR DESCRIPTION
1. recipe_view.dart 에서 검색 입력 박스 내 힌트 텍스트에 공백을 지우고 content padding 을 추가하였습니다.

// recipe_view.dart
````
child: TextField(
              decoration: InputDecoration(
            hintText: "검색어를 입력해 주세요.",
            contentPadding:
                EdgeInsetsDirectional.symmetric(vertical: 10, horizontal: 10),
            hintStyle: Theme.of(context).textTheme.labelMedium,
            border: InputBorder.none,
            suffixIcon: Icon(Icons.search, size: 24, color: Color(0xff2A2A2A)),
          )),

```