### PR TITLE
Fix: 요구사항 변경에 따른 테스트 코드 수정 && 재료 선택 시트 UI 변경

### DIFF
--- a/lib/src/ingredient/widget/ingredient_edit_bottom_sheet.dart
+++ b/lib/src/ingredient/widget/ingredient_edit_bottom_sheet.dart
@@ -72,22 +72,19 @@ class _IngredientEditBottomSheetState extends State<IngredientEditBottomSheet> {
                 startAt: widget.ingredient.startAt,
                 endAt: widget.ingredient.endAt),
           ),
-          Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              IngredientImage(
-                path: widget.ingredient.category.imagePath,
-                width: 300,
-                isFreezed: widget.ingredient.isFreezed,
-                isWarning: false,
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 23.3),
-                child: Text(widget.ingredient.name,
-                    style: Theme.of(context).textTheme.bodyMedium),
-              )
-            ],
+          IngredientImage.select(
+            isFreezed: widget.ingredient.isFreezed,
+            path: widget.ingredient.category.imagePath,
+            isWarning: false,
+            width: 250,
+          ),
+          Positioned(
+            bottom: 40,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 23.3),
+              child: Text(widget.ingredient.name,
+                  style: Theme.of(context).textTheme.bodyMedium),
+            ),
           )
         ],
       ),

--- a/lib/src/ingredient/widget/ingredient_expiration_date_chart.dart
+++ b/lib/src/ingredient/widget/ingredient_expiration_date_chart.dart
@@ -15,16 +15,20 @@ class IngredientExprationDateChart extends CustomPainter {
     final now = DateTime.now();
     final total = (endAt.difference(startAt).inHours).ceil();
     final rest = (endAt.difference(now).inHours).ceil();
-    final restToRadian = 2 * pi * rest / total;
-    final radius = (size.width / 2) * 0.8;
-    final paint = Paint()..color = const Color(0xfff3f3f3);
-    canvas.drawArc(
-        Rect.fromCircle(
-            center: Offset(size.width / 2, size.width / 2), radius: radius),
-        -pi / 2,
-        restToRadian,
-        true,
-        paint);
+    if (rest < 0) {
+      return;
+    } else {
+      final restToRadian = 2 * pi * rest / total;
+      final radius = (size.width / 2) * 0.8;
+      final paint = Paint()..color = const Color(0xfff3f3f3);
+      canvas.drawArc(
+          Rect.fromCircle(
+              center: Offset(size.width / 2, size.width / 2), radius: radius),
+          -pi / 2,
+          restToRadian,
+          true,
+          paint);
+    }
   }
 
   @override

--- a/lib/src/ingredient/widget/ingredient_image.dart
+++ b/lib/src/ingredient/widget/ingredient_image.dart
@@ -7,12 +7,29 @@ class IngredientImage extends StatelessWidget {
   final String path;
   final bool isWarning;
   final double width;
+  final double space;
   const IngredientImage(
       {super.key,
       this.isFreezed = false,
       required this.path,
       this.width = 110,
+      this.space = 30,
       required this.isWarning});
+
+  factory IngredientImage.select({
+    required bool isFreezed,
+    required String path,
+    required bool isWarning,
+    required double width,
+  }) {
+    return IngredientImage(
+      isFreezed: isFreezed,
+      path: path,
+      isWarning: isWarning,
+      width: width,
+      space: 150,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,14 +49,14 @@ class IngredientImage extends StatelessWidget {
         children: [
           ImageWidget(
             path: IceImage.background,
-            width: width + 30,
+            width: width + space,
           ),
           _icon(),
           Opacity(
             opacity: 0.6,
             child: ImageWidget(
               path: IceImage.foreground,
-              width: width + 30,
+              width: width + space,
             ),
           )
         ],

--- a/test/app/viewModel/app_view_model_test.dart
+++ b/test/app/viewModel/app_view_model_test.dart
@@ -7,8 +7,8 @@ void main() {
     setUp(() {
       viewModel = AppViewModel();
     });
-    test("초기 index 는 1이다.", () {
-      expect(viewModel.pageIndex, 1);
+    test("초기 index 는 0이다.", () {
+      expect(viewModel.pageIndex, 0);
     });
 
     test("changeIndex 메소드를 통해서 pageIndex를 바꿀 수 있다.", () {

--- a/test/ingredient/view/home_view_test.dart
+++ b/test/ingredient/view/home_view_test.dart
@@ -42,16 +42,6 @@ void main() {
       expect(find.byKey(const Key("header")), findsAtLeast(1));
       expect(find.byKey(const Key("freezer")), findsAtLeast(1));
       expect(find.byKey(const Key("fridge")), findsAtLeast(1));
-      expect(find.byKey(const Key("fab")), findsAtLeast(1));
-    });
-
-    testWidgets("사용자는 FAB을 통해서 Ingredient Add View로 이동할 수 있다.",
-        (WidgetTester tester) async {
-      await tester.pumpWidget(homeView);
-      await tester.tap(find.byType(FloatingActionButton));
-      await tester.pumpAndSettle();
-
-      expect(find.byType(IngredientAddView), findsOneWidget);
     });
 
     testWidgets("사용자의 냉장고 재료가 올바르게 렌더링 된다.", (WidgetTester tester) async {


### PR DESCRIPTION
1. 요구사항에 따라서 테스트 코드에 일부 수정이 있습니다.
HomeView에 위치하는 FAB은 이제 APP 수준에 위치하므로
HomveView UI 테스트에서 FAB 네비게이션 테스트와 렌더링 테스트가 삭제되었습니다.

test/app/viewModel/app_view_model_test.dart
```dart
   // 초기 인덱스 변경
    test("초기 index 는 0이다.", () {
      expect(viewModel.pageIndex, 0);
    });
```
test/ingredient/view/home_view_test.dart
네비게이션 테스트 삭제
```dart
    testWidgets("사용자는 FAB을 통해서 Ingredient Add View로 이동할 수 있다.",
        (WidgetTester tester) async {
      await tester.pumpWidget(homeView);
      await tester.tap(find.byType(FloatingActionButton));
      await tester.pumpAndSettle();

      expect(find.byType(IngredientAddView), findsOneWidget);
    });
```

삭제된 사항은 추후에 App UI 테스트에서 수행될 예정입니다.

modifed file
- test/app/viewModel/app_view_model_test.dart
- test/ingredient/view/home_view_test.dart

2. 재료 선택 시트 UI 조정 및 클래스 생성 방식 추가

재료 선택 시트에서 기간이 지난 재료는 더이상 남은 기한을 파이차트로 표현하지 않습니다.

```dart
...
  @override
  void paint(Canvas canvas, Size size) {
    final now = DateTime.now();
    final total = (endAt.difference(startAt).inHours).ceil();
    final rest = (endAt.difference(now).inHours).ceil();
    if (rest < 0) {
     // 남은 기한이 없는 경우에는 생략
      return;
    } else {
      final restToRadian = 2 * pi * rest / total;
      final radius = (size.width / 2) * 0.8;
      final paint = Paint()..color = const Color(0xfff3f3f3);
      canvas.drawArc(
          Rect.fromCircle(
              center: Offset(size.width / 2, size.width / 2), radius: radius),
          -pi / 2,
          restToRadian,
          true,
          paint);
    }
  }
```

재료 선택 시트의 UI가 기존에는 재료이미지와 재료의 이름이 세로로 나열되었다면, 재료의 이미지는 중앙에 재료의 이름은 아래에 나열됩니다.

```dart
Widget _middle() {
    final ratio = MediaQuery.of(context).devicePixelRatio;
    final line = 800 / ratio;
    return Padding(
      key: const Key("Ingredient Edit Bottom Sheet Middle"),
      padding: const EdgeInsets.only(top: 20.0),
      child: Stack(
        alignment: Alignment.center,
        children: [
          CustomPaint(
            size: Size(line, line),
            painter: IngredientExprationDateChart(
                startAt: widget.ingredient.startAt,
                endAt: widget.ingredient.endAt),
          ),
          IngredientImage.select(
            isFreezed: widget.ingredient.isFreezed,
            path: widget.ingredient.category.imagePath,
            isWarning: false,
            width: 250,
          ),
          Positioned(
            bottom: 40,
            child: Padding(
              padding: const EdgeInsets.only(top: 23.3),
              child: Text(widget.ingredient.name,
                  style: Theme.of(context).textTheme.bodyMedium),
            ),
          )
        ],
      ),
```

modified file
- lib/src/ingredient/widget/ingredient_expiration_date_chart.dart
- lib/src/ingredient/widget/ingredient_edit_bottom_sheet.dart

체크리스트
- [x] 테스트 코드 통과하는지?