### PR TITLE
Refactor: select ingredient image 코드 리팩토링

### DIFF
--- a/lib/src/ingredient/widget/select_ingredient_image.dart
+++ b/lib/src/ingredient/widget/select_ingredient_image.dart
@@ -22,13 +22,16 @@ class _SelectIngredientImageState extends State<SelectIngredientImage>
 
   @override
   void initState() {
+    // 얼음 에니메이션 컨트롤러
     _backgroundAnimationController = AnimationController(
-        duration: const Duration(milliseconds: 700), vsync: this);
+        duration: const Duration(milliseconds: 200), vsync: this);
     _foregroundAnimationController = AnimationController(
         duration: const Duration(milliseconds: 200), vsync: this);
+
+    // 얼음 애니메이션
     _backgroundAnimation = CurvedAnimation(
         parent: _backgroundAnimationController,
-        curve: Curves.elasticOut,
+        curve: Curves.easeOutBack,
         reverseCurve: Curves.fastOutSlowIn);
     _foregroundAnimation = CurvedAnimation(
         parent: _foregroundAnimationController, curve: Curves.fastOutSlowIn);
@@ -37,20 +40,19 @@ class _SelectIngredientImageState extends State<SelectIngredientImage>
 
   @override
   void didUpdateWidget(covariant SelectIngredientImage oldWidget) {
-    if ((widget.ingredient == null && oldWidget.ingredient == null) ||
-        (widget.ingredient == null && oldWidget.ingredient != null)) {
+    /// 이전 위젯과 다른 재료를 선택한 경우에는 애니메이션이 발생하지 않음.
+    if (widget.ingredient == oldWidget.ingredient) {
       return;
     }
-    if (widget.ingredient!.isFreezed) {
-      _backgroundAnimationController.duration =
-          const Duration(milliseconds: 700);
+
+    /// isFreezed의 옵셔널 체이닝을 통해서 null 방지 -> false 부여
+    final isFreezed = widget.ingredient?.isFreezed ?? false;
+    if (isFreezed) {
       _backgroundAnimationController.forward().then((_) {
         _foregroundAnimationController.forward();
       });
     } else {
       _foregroundAnimationController.reverse().then((_) {
-        _backgroundAnimationController.duration =
-            const Duration(milliseconds: 200);
         _backgroundAnimationController.reverse();
       });
     }
@@ -110,7 +112,9 @@ class _SelectIngredientImageState extends State<SelectIngredientImage>
       );
 }
 
-final class IceImage {
+/// [IceImage]는 [SelectIngredientImage]에서 사용되는
+/// 얼음 백그라운드와 포어그라운드 이미지 path의 String getter 확장입니다.
+extension IceImage on ImagePath {
   static String get background => "assets/images/ice_background.png";
   static String get foreground => "assets/images/ice_foreground.png";
 }


### PR DESCRIPTION
SelectIngredientImage의 소스코드이 일부 부분이 리팩토링 되었습니다.


1. didUpdateWidget() 메소드 리팩토링

```dart
  @override
  void didUpdateWidget(covariant SelectIngredientImage oldWidget) {
    /// 이전 위젯과 다른 재료를 선택한 경우에는 애니메이션이 발생하지 않음.
    if (widget.ingredient == oldWidget.ingredient) {
      return;
    }

    /// isFreezed의 옵셔널 체이닝을 통해서 null 방지 -> false 부여
    final isFreezed = widget.ingredient?.isFreezed ?? false;
    if (isFreezed) {
      _backgroundAnimationController.forward().then((_) {
        _foregroundAnimationController.forward();
      });
    } else {
      _foregroundAnimationController.reverse().then((_) {
        _backgroundAnimationController.reverse();
      });
    }
    super.didUpdateWidget(widget);
  }
```

기존의 복잡한  조건문보다 간결하게 변경되었습니다. 기존에는 widget과 oldWidget의 null 상태에 따른 복잡한 조건에서 간결하게 차이를 비교하도록 리팩토링하였습니다.

또한, isFreezed 조건 변수를 추가하여 isFreezed의 옵셔널 체이닝을 통해 null 안정성을 높였습니다.


2. IceImage 확장 추가

기존에는 IceImage라는 클래스를 통해서 정적인 이미지 path를 제공했으나 가독성을 높이기 위하여 IceImage라는 ImagePath 확장으로 변경되었습니다.

```dart
/// [IceImage]는 [SelectIngredientImage]에서 사용되는
/// 얼음 백그라운드와 포어그라운드 이미지 path의 String getter 확장입니다.
extension IceImage on ImagePath {
  static String get background => "assets/images/ice_background.png";
  static String get foreground => "assets/images/ice_foreground.png";
}
```

modified file
- lib/src/ingredient/widget/select_ingredient_image.dart