### PR TITLE
Feat: 레시피 페이지네이션 구현

### DIFF
--- a/lib/src/data/recipe/datasource/remote_datasource.dart
+++ b/lib/src/data/recipe/datasource/remote_datasource.dart
@@ -12,20 +12,20 @@ class RemoteDatasourceImpl implements RemoteDatasource {
   });
 
   @override
-  Future<List<Map<String, dynamic>>> getAllRecipes() {
-    return apiClient
-        .get(Uri.parse("$baseUrl/api/recipes?page=0&size=10"))
-        .then((response) {
-      if (response.statusCode == 200) {
-        return List<Map<String, dynamic>>.from(
-            jsonDecode(utf8.decode(response.bodyBytes)));
-      } else {
-        throw jsonDecode(utf8.decode(response.bodyBytes));
-      }
-    });
+  Future<List<Map<String, dynamic>>> getAllRecipes(
+      {int page = 0, int size = 10}) async {
+    final response = await apiClient
+        .get(Uri.parse("$baseUrl/api/recipes?page=$page&size=$size"));
+    if (response.statusCode == 200) {
+      return List<Map<String, dynamic>>.from(
+          jsonDecode(utf8.decode(response.bodyBytes)));
+    } else {
+      throw jsonDecode(utf8.decode(response.bodyBytes));
+    }
   }
 }
 
 abstract class RemoteDatasource {
-  Future<List<Map<String, dynamic>>> getAllRecipes();
+  Future<List<Map<String, dynamic>>> getAllRecipes(
+      {int page = 0, int size = 10});
 }

--- a/lib/src/data/recipe/model/recipe.dart
+++ b/lib/src/data/recipe/model/recipe.dart
@@ -69,3 +69,32 @@ class Recipe {
         "steps": steps.map((item) => item.toJson()).toList()
       };
 }
+
+class CursorPaginationMeta {
+  final int page;
+  final int size;
+
+  CursorPaginationMeta({required this.page, required this.size});
+
+  factory CursorPaginationMeta.fromJson(Map<String, dynamic> json) {
+    return CursorPaginationMeta(page: json['page'], size: json['size']);
+  }
+}
+
+class RecipeResponse {
+  final List<Recipe> recipes;
+  final CursorPaginationMeta meta;
+
+  RecipeResponse({required this.recipes, required this.meta});
+
+  factory RecipeResponse.fromJson(Map<String, dynamic> json) {
+    var recipesJson = json['recipes'] as List;
+    List<Recipe> recipesList =
+        recipesJson.map((recipe) => Recipe.fromJson(recipe)).toList();
+
+    return RecipeResponse(
+      recipes: recipesList,
+      meta: CursorPaginationMeta.fromJson(json['meta']),
+    );
+  }
+}

--- a/lib/src/data/recipe/repository/recipe_respository.dart
+++ b/lib/src/data/recipe/repository/recipe_respository.dart
@@ -7,12 +7,13 @@ class RecipeRepositoryImpl implements RecipeRepository {
   RecipeRepositoryImpl({required this.remoteDatasource});
 
   @override
-  Future<List<Recipe>> getAllRecipes() {
-    return remoteDatasource.getAllRecipes().then(
-        (response) => response.map((json) => Recipe.fromJson(json)).toList());
+  Future<List<Recipe>> getAllRecipes({int page = 0, int size = 10}) async {
+    final response =
+        await remoteDatasource.getAllRecipes(page: page, size: size);
+    return response.map((json) => Recipe.fromJson(json)).toList();
   }
 }
 
 abstract class RecipeRepository {
-  Future<List<Recipe>> getAllRecipes();
+  Future<List<Recipe>> getAllRecipes({int page, int size});
 }

--- a/lib/src/ui/app/view/app_view.dart
+++ b/lib/src/ui/app/view/app_view.dart
@@ -4,7 +4,7 @@ import 'package:yum_application/src/ui/app/viewModel/app_view_model.dart';
 import 'package:yum_application/src/ui/challenge/view/challenge_view.dart';
 import 'package:yum_application/src/ui/common/widgets/image_widget.dart';
 import 'package:yum_application/src/ui/ingredient/view/home_view.dart';
-import 'package:yum_application/src/ui/recipe/view/recipe_view.dart';
+import 'package:yum_application/src/ui/recipe/recipe_ui.dart';
 import 'package:yum_application/src/ui/user/view/mypage_view.dart';
 
 class AppView extends StatelessWidget {
@@ -27,7 +27,7 @@ class AppView extends StatelessWidget {
             HomeView(
               key: Key("app view ingredient view"),
             ),
-            RecipeView(
+            RecipeUI(
               key: Key("app view recipe view"),
             ),
             ChallengeView(

--- a/lib/src/ui/recipe/model/recipe_view_event.dart
+++ b/lib/src/ui/recipe/model/recipe_view_event.dart
@@ -1,0 +1,15 @@
+import 'package:equatable/equatable.dart';
+
+sealed class RecipeViewEvent extends Equatable {}
+
+final class GetFirstPages extends RecipeViewEvent {
+  @override
+  List<Object?> get props => [];
+}
+
+final class GetNextPages extends RecipeViewEvent {
+  final int page;
+  GetNextPages({required this.page});
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/src/ui/recipe/model/recipe_view_state.dart
+++ b/lib/src/ui/recipe/model/recipe_view_state.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+import 'package:yum_application/src/data/recipe/model/recipe.dart';
+
+sealed class RecipeViewState extends Equatable {}
+
+final class InitState extends RecipeViewState {
+  @override
+  List<Object?> get props => [];
+}
+
+final class LoadingState extends RecipeViewState {
+  @override
+  List<Object?> get props => [];
+}
+
+final class ErrorState extends RecipeViewState {
+  @override
+  List<Object?> get props => [];
+}
+
+final class LoadedState extends RecipeViewState {
+  final List<Recipe> recipes;
+
+  LoadedState({required this.recipes});
+
+  LoadedState copyWith({List<Recipe>? recipes}) {
+    return LoadedState(recipes: recipes ?? this.recipes);
+  }
+
+  @override
+  List<Object?> get props => [recipes];
+}

--- a/lib/src/ui/recipe/recipe_ui.dart
+++ b/lib/src/ui/recipe/recipe_ui.dart
@@ -1,0 +1,223 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:yum_application/src/data/recipe/model/recipe.dart';
+import 'package:yum_application/src/ui/recipe/model/recipe_view_event.dart';
+import 'package:yum_application/src/ui/recipe/view/recipe_view.dart';
+import 'package:yum_application/src/ui/recipe/viewModel/recipe_view_model.dart';
+
+import 'package:yum_application/src/ui/recipe/view/recipe_detail_view.dart';
+import 'package:yum_application/src/ui/recipe/widget/ingrdient_keyword.dart';
+
+class RecipeUI extends StatefulWidget {
+  const RecipeUI({super.key});
+
+  @override
+  State<RecipeUI> createState() => _RecipeUIState();
+}
+
+class _RecipeUIState extends State<RecipeUI> {
+  List<String> ingredients = ["남은 음식", "양파", "버섯"];
+
+  int _page = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.read<RecipeViewModel>();
+    return Scaffold(
+      appBar: _appBar(),
+      body: NotificationListener<ScrollNotification>(
+        onNotification: (notification) {
+          var matrics = notification.metrics;
+          if (matrics.axisDirection != AxisDirection.down) {
+            return false;
+          }
+          if (matrics.extentAfter <= 0) {
+            final event = GetNextPages(page: ++_page);
+            viewModel.onEvent(event);
+            setState(() {});
+          }
+          return false;
+        },
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              _button(),
+              _menu(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  PreferredSizeWidget _appBar() => PreferredSize(
+        preferredSize: Size.fromHeight(AppBar().preferredSize.height + 182),
+        child: Builder(builder: (context) {
+          return ClipRRect(
+            borderRadius: BorderRadius.circular(12.0),
+            child: AppBar(
+              backgroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
+              foregroundColor: Theme.of(context).colorScheme.onSecondary,
+              leading: GestureDetector(
+                onTap: Navigator.of(context).pop,
+                child: const Icon(
+                  Icons.arrow_back_ios,
+                ),
+              ),
+              elevation: 0,
+              title: Text(
+                "레시피 찾기",
+                style: Theme.of(context).textTheme.headlineLarge,
+              ),
+              bottom: PreferredSize(
+                preferredSize: const Size.fromHeight(172),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 20.0, vertical: 22.0),
+                  child: Column(
+                    children: [
+                      _search(),
+                      _keyword(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        }),
+      );
+
+  Widget _search() => Builder(builder: (context) {
+        return Container(
+          width: 390,
+          height: 40,
+          decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12.0),
+              color: const Color(0xffF3F3F3)),
+          child: TextField(
+              decoration: InputDecoration(
+            hintText: "검색어를 입력해 주세요.",
+            contentPadding: const EdgeInsetsDirectional.symmetric(
+                vertical: 10, horizontal: 10),
+            hintStyle: Theme.of(context).textTheme.labelMedium,
+            border: InputBorder.none,
+            suffixIcon:
+                const Icon(Icons.search, size: 24, color: Color(0xff2A2A2A)),
+          )),
+        );
+      });
+
+  Widget _keyword() => Builder(builder: (context) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.only(top: 20.0, bottom: 10),
+            ),
+            Text(
+              "기한 임박! 먹어서 구해 주세요!!",
+              style: Theme.of(context).textTheme.headlineSmall,
+              textAlign: TextAlign.left,
+            ),
+            Row(
+              children: [
+                _customContainer("남은 음식"),
+                Padding(
+                  padding: const EdgeInsets.only(left: 10.0),
+                  child: _customContainer("버섯"),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(left: 10.0),
+                  child: _customContainer("양파"),
+                ),
+                _plus(),
+              ],
+            ),
+          ],
+        );
+      });
+
+  Widget _customContainer(String text) => Padding(
+        padding: const EdgeInsets.only(
+          top: 10.0,
+        ),
+        child: Builder(builder: (context) {
+          return Container(
+            padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
+            decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(20),
+                color: Colors.transparent,
+                border: Border.all(color: const Color(0xff362703))),
+            alignment: Alignment.center,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  text,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                // GestureDetector(
+                //   onTap: () {
+                //     setState(() {
+                //       ingredients.remove(text);
+                //     });
+                //   },
+                // ),
+                const Icon(Icons.close),
+              ],
+            ),
+          );
+        }),
+      );
+
+  Widget _plus() => Padding(
+        padding: const EdgeInsets.only(left: 50.0, top: 7),
+        child: GestureDetector(
+          onTap: () {},
+          child: const Icon(
+            Icons.add_circle,
+            size: 40,
+          ),
+        ),
+      );
+
+  Widget _button() => Builder(builder: (context) {
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 20, right: 22),
+              child: Container(
+                width: 75,
+                height: 34,
+                decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    color: const Color(0xff362703)),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(left: 8),
+                      child: Text(
+                        "추천순",
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ),
+                    const Icon(
+                      Icons.arrow_drop_down_sharp,
+                      color: Colors.white,
+                    )
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      });
+
+  Widget _menu() => RecipeView();
+
+  Widget _ingredientKeyword(String text) => IngredientKeyword(text: text);
+}

--- a/lib/src/ui/recipe/view/recipe_view.dart
+++ b/lib/src/ui/recipe/view/recipe_view.dart
@@ -1,325 +1,127 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:yum_application/main.dart';
 import 'package:yum_application/src/data/recipe/model/recipe.dart';
-import 'package:yum_application/src/ui/recipe/view/recipe_%20register_view.dart';
+import 'package:yum_application/src/ui/common/widgets/loading_progress_indicator.dart';
+import 'package:yum_application/src/ui/recipe/model/recipe_view_state.dart';
 import 'package:yum_application/src/ui/recipe/view/recipe_detail_view.dart';
 import 'package:yum_application/src/ui/recipe/viewModel/recipe_view_model.dart';
+import 'package:yum_application/src/ui/recipe/widget/ingrdient_keyword.dart';
 
-class RecipeView extends StatefulWidget {
+class RecipeView extends StatelessWidget {
   const RecipeView({super.key});
 
   @override
-  State<RecipeView> createState() => _RecipeViewState();
-}
-
-class _RecipeViewState extends State<RecipeView> {
-  List<String> ingredients = ["남은 음식", "양파", "버섯"];
-
-  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: _appBar(),
-      // floatingActionButton: _floating(),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            _button(),
-            _menu(),
-          ],
+    final viewModel = context.watch<RecipeViewModel>();
+    final state = viewModel.state;
+
+    return switch (state) {
+      InitState() => Center(
+          child: LoadingProgressIndicator(),
         ),
-      ),
-    );
-  }
-
-  PreferredSizeWidget _appBar() => PreferredSize(
-        preferredSize: Size.fromHeight(AppBar().preferredSize.height + 182),
-        child: Builder(builder: (context) {
-          return ClipRRect(
-            borderRadius: BorderRadius.circular(12.0),
-            child: AppBar(
-              backgroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
-              foregroundColor: Theme.of(context).colorScheme.onSecondary,
-              leading: GestureDetector(
-                onTap: Navigator.of(context).pop,
-                child: const Icon(
-                  Icons.arrow_back_ios,
-                ),
-              ),
-              elevation: 0,
-              title: Text(
-                "레시피 찾기",
-                style: Theme.of(context).textTheme.headlineLarge,
-              ),
-              bottom: PreferredSize(
-                preferredSize: const Size.fromHeight(172),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 20.0, vertical: 22.0),
-                  child: Column(
-                    children: [
-                      _search(),
-                      _keyword(),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          );
-        }),
-      );
-
-  Widget _search() => Builder(builder: (context) {
-        return Container(
-          width: 390,
-          height: 40,
-          decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12.0),
-              color: const Color(0xffF3F3F3)),
-          child: TextField(
-              decoration: InputDecoration(
-            hintText: "검색어를 입력해 주세요.",
-            contentPadding: const EdgeInsetsDirectional.symmetric(
-                vertical: 10, horizontal: 10),
-            hintStyle: Theme.of(context).textTheme.labelMedium,
-            border: InputBorder.none,
-            suffixIcon:
-                const Icon(Icons.search, size: 24, color: Color(0xff2A2A2A)),
-          )),
-        );
-      });
-
-  Widget _keyword() => Builder(builder: (context) {
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Padding(
-              padding: EdgeInsets.only(top: 20.0, bottom: 10),
-            ),
-            Text(
-              "사망 직전! 먹어서 구해 주세요!!",
-              style: Theme.of(context).textTheme.headlineSmall,
-              textAlign: TextAlign.left,
-            ),
-            Row(
-              children: [
-                _customContainer("남은 음식"),
-                Padding(
-                  padding: const EdgeInsets.only(left: 10.0),
-                  child: _customContainer("버섯"),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(left: 10.0),
-                  child: _customContainer("양파"),
-                ),
-                _plus(),
-              ],
-            ),
-          ],
-        );
-      });
-
-  Widget _customContainer(String text) => Padding(
-        padding: const EdgeInsets.only(
-          top: 10.0,
+      LoadingState() => Center(
+          child: LoadingProgressIndicator(),
         ),
-        child: Builder(builder: (context) {
-          return Container(
-            padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
-            decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(20),
-                color: Colors.transparent,
-                border: Border.all(color: const Color(0xff362703))),
-            alignment: Alignment.center,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  text,
-                  style: Theme.of(context).textTheme.bodyMedium,
-                ),
-                // GestureDetector(
-                //   onTap: () {
-                //     setState(() {
-                //       ingredients.remove(text);
-                //     });
-                //   },
-                // ),
-                const Icon(Icons.close),
-              ],
-            ),
-          );
-        }),
-      );
-
-  Widget _plus() => Padding(
-        padding: const EdgeInsets.only(left: 50.0, top: 7),
-        child: GestureDetector(
-          onTap: () {},
-          child: const Icon(
-            Icons.add_circle,
-            size: 40,
-          ),
+      ErrorState() => Center(
+          child: Text("error 가 발생"),
         ),
-      );
-
-  Widget _button() => Builder(builder: (context) {
-        return Row(
-          mainAxisAlignment: MainAxisAlignment.end,
+      LoadedState() => Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 20, right: 22),
-              child: Container(
-                width: 75,
-                height: 34,
-                decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(12),
-                    color: const Color(0xff362703)),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8),
-                      child: Text(
-                        "추천순",
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                    ),
-                    const Icon(
-                      Icons.arrow_drop_down_sharp,
-                      color: Colors.white,
-                    )
-                  ],
-                ),
-              ),
-            ),
-          ],
-        );
-      });
-
-  Widget _menu() =>
-      Consumer<RecipeViewModel>(builder: (context, provider, child) {
-        final recipes = provider.recipes;
-        return Column(
-          children: List.generate(recipes.length, (index) {
-            final Recipe recipe = recipes[index];
-            return Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => const RecipeDetailView()));
-                },
-                child: Container(
-                  height: 190,
-                  decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(16)),
-                  child: Row(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(left: 20.0),
-                        child: Container(
-                          width: 154,
-                          height: 150,
-                          decoration: BoxDecoration(
-                              color: const Color((0xFFEEEEEE)),
-                              borderRadius: BorderRadius.circular(16)),
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(16),
-                            child: CachedNetworkImage(
-                              imageUrl: recipe.imageUrl,
-                              fit: BoxFit.cover,
+            // 레시피 목록 생성
+            ...List.generate(state.recipes.length, (index) {
+              final Recipe recipe = state.recipes[index];
+              return Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: GestureDetector(
+                  onTap: () {
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => const RecipeDetailView()));
+                  },
+                  child: Container(
+                    height: 190,
+                    decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(16)),
+                    child: Row(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(left: 20.0),
+                          child: Container(
+                            width: 154,
+                            height: 150,
+                            decoration: BoxDecoration(
+                                color: const Color(0xFFEEEEEE),
+                                borderRadius: BorderRadius.circular(16)),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(16),
+                              child: CachedNetworkImage(
+                                imageUrl: recipe.imageUrl,
+                                fit: BoxFit.cover,
+                                placeholder: (context, url) => const Center(
+                                    child: CircularProgressIndicator()),
+                                errorWidget: (context, url, error) =>
+                                    const Icon(Icons.error),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.only(top: 20, left: 20),
-                              child: Text(
-                                recipe.name,
-                                style:
-                                    Theme.of(context).textTheme.headlineSmall,
-                                overflow: TextOverflow.ellipsis,
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding:
+                                    const EdgeInsets.only(top: 20, left: 20),
+                                child: Text(
+                                  recipe.name,
+                                  style:
+                                      Theme.of(context).textTheme.headlineSmall,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
                               ),
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(top: 10, left: 20),
-                              child: Text(
-                                recipe.description,
-                                style: Theme.of(context).textTheme.labelSmall,
-                                overflow: TextOverflow.ellipsis,
+                              Padding(
+                                padding:
+                                    const EdgeInsets.only(top: 10, left: 20),
+                                child: Text(
+                                  recipe.description,
+                                  style: Theme.of(context).textTheme.labelSmall,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
                               ),
-                            ),
-                            Row(
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.only(left: 20),
-                                  child: _ingredientKeyword("토마토"),
-                                ),
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 4),
-                                  child: _ingredientKeyword("양파"),
-                                ),
-                                _ingredientKeyword("버섯"),
-                              ],
-                            ),
-                            Row(
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.only(left: 20),
-                                  child: _ingredientKeyword("토마토"),
-                                ),
-                                Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 4.0),
-                                  child: _ingredientKeyword("토마토"),
-                                ),
-                              ],
-                            ),
-                          ],
+                              Row(
+                                children: [
+                                  Padding(
+                                    padding: const EdgeInsets.only(left: 20),
+                                    child: IngredientKeyword(text: "토마토"),
+                                  ),
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 4),
+                                    child: IngredientKeyword(text: "양파"),
+                                  ),
+                                  IngredientKeyword(text: "버섯"),
+                                ],
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            );
-          }),
-        );
-      });
+              );
+            }),
 
-  Widget _ingredientKeyword(String text) => Padding(
-        padding: const EdgeInsets.only(
-          top: 10.0,
+            if (viewModel.isLoading)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                child: CircularProgressIndicator(),
+              ),
+          ],
         ),
-        child: Builder(builder: (context) {
-          return Container(
-            height: 26,
-            padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
-            decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(20),
-                color: const Color.fromARGB(15, 58, 57, 57)),
-            alignment: Alignment.center,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  text,
-                  style: Theme.of(context).textTheme.bodyMedium,
-                ),
-              ],
-            ),
-          );
-        }),
-      );
+    };
+  }
 }

--- a/lib/src/ui/recipe/viewModel/recipe_view_model.dart
+++ b/lib/src/ui/recipe/viewModel/recipe_view_model.dart
@@ -1,23 +1,66 @@
 import 'package:flutter/material.dart';
 import 'package:yum_application/src/data/recipe/model/recipe.dart';
 import 'package:yum_application/src/data/recipe/repository/recipe_respository.dart';
+import 'package:yum_application/src/ui/recipe/model/recipe_view_event.dart';
+import 'package:yum_application/src/ui/recipe/model/recipe_view_state.dart';
 
 class RecipeViewModel extends ChangeNotifier {
   final RecipeRepository recipeRepository;
-  List<Recipe> _recipes = List.empty(growable: true);
-
-  List<Recipe> get recipes => _recipes;
 
   RecipeViewModel({required this.recipeRepository}) {
-    _fetchData();
-    print("레시피 뷰모델 생성");
+    getFirstPages();
   }
 
-  void _fetchData() async {
-    final result = await recipeRepository.getAllRecipes();
-    print(result);
-    _recipes.clear();
-    _recipes.addAll(result);
-    notifyListeners();
+  RecipeViewState _state = InitState();
+  RecipeViewState get state => _state;
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  void onEvent(RecipeViewEvent event) {
+    switch (event) {
+      case GetFirstPages():
+        getFirstPages();
+        break;
+      case GetNextPages():
+        getSecondPages(event.page);
+        break;
+    }
+  }
+
+  Future<void> getFirstPages() async {
+    try {
+      _isLoading = true;
+      notifyListeners();
+
+      final recipes = await recipeRepository.getAllRecipes();
+      _state = LoadedState(recipes: recipes);
+    } catch (e) {
+      _state = ErrorState();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> getSecondPages(int page) async {
+    try {
+      _isLoading = true;
+      notifyListeners();
+
+      if (_state is LoadedState) {
+        final currState = _state as LoadedState;
+        final newRecipes = await recipeRepository.getAllRecipes(page: page);
+        _state = currState.copyWith(recipes: [
+          ...currState.recipes,
+          ...newRecipes,
+        ]);
+      }
+    } catch (e) {
+      _state = ErrorState();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 }

--- a/lib/src/ui/recipe/widget/ingrdient_keyword.dart
+++ b/lib/src/ui/recipe/widget/ingrdient_keyword.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class IngredientKeyword extends StatelessWidget {
+  final String text;
+  const IngredientKeyword({super.key, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        top: 10.0,
+      ),
+      child: Builder(builder: (context) {
+        return Container(
+          height: 26,
+          padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
+          decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(20),
+              color: const Color.fromARGB(15, 58, 57, 57)),
+          alignment: Alignment.center,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                text,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+    ;
+  }
+}

--- a/test/app/view/app_ui_test.dart
+++ b/test/app/view/app_ui_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:provider/provider.dart';
+import 'package:yum_application/src/ui/recipe/viewModel/recipe_view_model.dart';
 import 'package:yum_application/src/ui/app/page/app_page.dart';
 import 'package:yum_application/src/ui/ingredient/viewModel/ingredient_view_model.dart';
-import 'package:yum_application/src/ui/recipe/viewModel/recipe_view_model.dart';
 
 import 'app_ui_test.mocks.dart';
 
@@ -16,7 +16,7 @@ void main() {
   late Widget widget;
   group("App UI Test", () {
     ingredientViewModel = MockRefreginatorIngredientViewModel();
-    recipeViewModel = MockRecipeViewModel();
+    recipeViewModel = MockRecipeViewModel() as RecipeViewModel;
     setUpAll(() {
       widget = MultiProvider(
         providers: [

--- a/test/app/view/app_ui_test.mocks.dart
+++ b/test/app/view/app_ui_test.mocks.dart
@@ -12,7 +12,6 @@ import 'package:yum_application/src/data/ingredient/entity/refreginator_ingredie
     as _i7;
 import 'package:yum_application/src/data/ingredient/repository/ingredient_repository.dart'
     as _i2;
-import 'package:yum_application/src/data/recipe/model/recipe.dart' as _i12;
 import 'package:yum_application/src/data/recipe/repository/recipe_respository.dart'
     as _i3;
 import 'package:yum_application/src/ui/common/enums/status.dart' as _i5;
@@ -20,6 +19,10 @@ import 'package:yum_application/src/ui/ingredient/model/basic_ingredient.dart'
     as _i9;
 import 'package:yum_application/src/ui/ingredient/viewModel/ingredient_view_model.dart'
     as _i4;
+import 'package:yum_application/src/ui/recipe/model/recipe_view_event.dart'
+    as _i13;
+import 'package:yum_application/src/ui/recipe/model/recipe_view_state.dart'
+    as _i12;
 import 'package:yum_application/src/ui/recipe/viewModel/recipe_view_model.dart'
     as _i11;
 
@@ -351,11 +354,24 @@ class MockRecipeViewModel extends _i1.Mock implements _i11.RecipeViewModel {
       ) as _i3.RecipeRepository);
 
   @override
-  List<_i12.Recipe> get recipes => (super.noSuchMethod(
-        Invocation.getter(#recipes),
-        returnValue: <_i12.Recipe>[],
-        returnValueForMissingStub: <_i12.Recipe>[],
-      ) as List<_i12.Recipe>);
+  _i12.RecipeViewState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i6.dummyValue<_i12.RecipeViewState>(
+          this,
+          Invocation.getter(#state),
+        ),
+        returnValueForMissingStub: _i6.dummyValue<_i12.RecipeViewState>(
+          this,
+          Invocation.getter(#state),
+        ),
+      ) as _i12.RecipeViewState);
+
+  @override
+  bool get isLoading => (super.noSuchMethod(
+        Invocation.getter(#isLoading),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -363,6 +379,33 @@ class MockRecipeViewModel extends _i1.Mock implements _i11.RecipeViewModel {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
+  @override
+  void onEvent(_i13.RecipeViewEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #onEvent,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void getFirstPages() => super.noSuchMethod(
+        Invocation.method(
+          #getFirstPages,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void getSecondPages(int? page) => super.noSuchMethod(
+        Invocation.method(
+          #getSecondPages,
+          [page],
+        ),
+        returnValueForMissingStub: null,
+      );
 
   @override
   void addListener(_i10.VoidCallback? listener) => super.noSuchMethod(

--- a/test/recipe/view/recipe_resister_view_test.dart
+++ b/test/recipe/view/recipe_resister_view_test.dart
@@ -3,8 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:provider/provider.dart';
 import 'package:yum_application/src/data/recipe/repository/recipe_respository.dart';
-import 'package:yum_application/src/ui/recipe/view/recipe_%20register_view.dart';
 import 'package:yum_application/src/ui/recipe/viewModel/recipe_view_model.dart';
+import 'package:yum_application/src/ui/recipe/view/recipe_%20register_view.dart';
 
 import 'recipe_resister_view_test.mocks.dart';
 

--- a/test/recipe/view/recipe_resister_view_test.mocks.dart
+++ b/test/recipe/view/recipe_resister_view_test.mocks.dart
@@ -28,10 +28,18 @@ import 'package:yum_application/src/data/recipe/repository/recipe_respository.da
 /// See the documentation for Mockito's code generation for more information.
 class MockRecipeRepository extends _i1.Mock implements _i2.RecipeRepository {
   @override
-  _i3.Future<List<_i4.Recipe>> getAllRecipes() => (super.noSuchMethod(
+  _i3.Future<List<_i4.Recipe>> getAllRecipes({
+    int? page,
+    int? size,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getAllRecipes,
           [],
+          {
+            #page: page,
+            #size: size,
+          },
         ),
         returnValue: _i3.Future<List<_i4.Recipe>>.value(<_i4.Recipe>[]),
         returnValueForMissingStub:


### PR DESCRIPTION
1. 레시피 찾는 페이지에서 로딩 시에 10 개씩 레시피를 불러오도록 페이지네이션 기능을 구현하였습니다.
```recipe_ui.dart
  int _page = 0;

  @override
  Widget build(BuildContext context) {
    final viewModel = context.read<RecipeViewModel>();
    return Scaffold(
      appBar: _appBar(),
      body: NotificationListener<ScrollNotification>(
        onNotification: (notification) {
          var matrics = notification.metrics;
          if (matrics.axisDirection != AxisDirection.down) {
            return false;
          }
          if (matrics.extentAfter <= 0) {
            final event = GetNextPages(page: ++_page);
            viewModel.onEvent(event);
            setState(() {});
          }
          return false;
        },
```
페이지의 초기값을 0 으로 지정한 뒤, 리스트 끝에 도달하게 되면 페이지를 증가시키도록 코드를 구현하였습니다.